### PR TITLE
Extract geosearch to be consumed by the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ _Type:_ `Function`
 
 _Default:_`false`
 
+_Optional:_ `true`
+
 _Description:_ Function that returns the bounding box of the current visible
 map.
 
@@ -132,4 +134,23 @@ _Example_: `(data) => data` where data is:
     "lng": -96.40777587890625
   }
 }```
+
+### providerInput:
+_Type:_ `string`
+
+_Optional:_ `true`
+
+_Description:_ String to use to query geosearch control.
+
+``` NOTE: Currently only available when provider = 'openstreet' ```
+
+
+### providerResults: (data: ResultType[] | []) => void;
+_Type:_ `Function`
+
+_Optional:_ `true`
+
+_Description:_ Function to return geosearch results to UI.
+
+_Required:_ If `providerInput` is supplied to Map. 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,16 @@ type LatType = {
         lng: Number,
     }
 }
-
+type ResultType = {
+    x: Number, // lon,
+    y: Number, // lat,
+    label: String, // formatted address
+    bounds: [
+        [Number, Number], // s, w - lat, lon
+        [Number, Number], // n, e - lat, lon
+    ],
+    raw: {}, // raw provider result
+};
 
 export interface MapProps {
     editable: boolean;
@@ -24,6 +33,8 @@ export interface MapProps {
     markerHtml?: string;
     mapCount?: number;
     getBounding?: (data?: LatType) => void;
+    providerResults?: (data?: ResultType[]) => void;
+    providerInput?: string;
 }
 declare class Map extends React.Component<MapProps, any> {}
 export default Map

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,23 +3,33 @@ import * as React from 'react';
 
 type LatType = {
     northeast: {
-        lat: Number,
-        lng: Number,
+        lat: Number
+        lng: Number
     },
     southwest: {
-        lat: Number,
-        lng: Number,
+        lat: Number
+        lng: Number
     }
 }
+type RawType = {
+    boundingbox: string[]
+    class: string
+    display_name: string
+    importance: number
+    lat: string
+    license: string
+    lon: string
+    osm_id: number
+    osm_type: string
+    place_id: number
+    type: string
+}
 type ResultType = {
-    x: Number, // lon,
-    y: Number, // lat,
-    label: String, // formatted address
-    bounds: [
-        [Number, Number], // s, w - lat, lon
-        [Number, Number], // n, e - lat, lon
-    ],
-    raw: {}, // raw provider result
+    x: string // lon,
+    y: string // lat,
+    label: string // formatted address
+    bounds: string[][]
+    raw: RawType // raw provider result
 };
 
 export interface MapProps {
@@ -33,7 +43,7 @@ export interface MapProps {
     markerHtml?: string;
     mapCount?: number;
     getBounding?: (data?: LatType) => void;
-    providerResults?: (data?: ResultType[]) => void;
+    providerResults?: (data: ResultType[] | []) => void;
     providerInput?: string;
 }
 declare class Map extends React.Component<MapProps, any> {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-leaflet",
-  "version": "1.0.2",
+  "version": "1.0.2.1",
   "description": "A React map component that allows geoJSON shapes to be drawn, edited, and loaded into leaflet layers",
   "main": "dist/Map.js",
   "types": "dist/index.d.ts",

--- a/src/Map.js
+++ b/src/Map.js
@@ -10,6 +10,8 @@ import { GeoSearchControl } from "leaflet-geosearch";
 import "./Map.css";
 import generateIcon, { getBounds, addArea } from "./helpers";
 import providerSwitch from './providers';
+import { OpenStreetMapProvider } from 'leaflet-geosearch';
+
 
 class Map extends React.Component {
   state = {
@@ -387,14 +389,22 @@ class Map extends React.Component {
     }
   }
   shouldComponentUpdate(prevState, nextState, nextProps, prevProps) {
+    console.log(prevProps, nextProps)
     if (isEqual(prevState.features, nextState.features)) {
       return false;
     }
     return true;
   }
-
+  componentWillReceiveProps(nextProps) {
+    console.log(nextProps.providerInput, this.props.providerInput)
+    if (nextProps.providerInput !== this.props.providerInput) {
+      const openStreet = new OpenStreetMapProvider({ params: {countrycodes: 'us'}})
+      const result = openStreet.search({ query: nextProps.providerInput}).then((result) => this.props.providerResults(result))
+      return true;
+    }
+  }
   render() {
-    const mapid = `mapid${!this.props.mapCount ? '' : ` ${this.props.mapCount.toString()}`}`
+      const mapid = `mapid${!this.props.mapCount ? '' : ` ${this.props.mapCount.toString()}`}`
     return (<div id={mapid} className='mapbox'/>);
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,7 @@ export interface MapProps<> {
         markerHtml: string;
         mapCount: number;
         getBounding?: (data?: LatType) => void;
-        providerResults: (data: ResultType[] | []) => void;
+        providerResults?: (data: ResultType[] | []) => void;
         providerInput?: string;
 }
 declare const Map: React.Component<MapProps>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,16 @@ type LatType = {
                 lng: Number,
         }
 }
+type ResultType = {
+        x: Number, // lon,
+        y: Number, // lat,
+        label: String, // formatted address
+        bounds: [
+                [Number, Number], // s, w - lat, lon
+                [Number, Number], // n, e - lat, lon
+        ],
+        raw: {}, // raw provider result
+};
 export interface MapProps<> {
         editable: boolean;
         cutMode?: boolean;
@@ -21,7 +31,9 @@ export interface MapProps<> {
         center: Array<number>;
         markerHtml: string;
         mapCount: number;
-        getBounding?: (data?: LatType) => void
+        getBounding?: (data?: LatType) => void;
+        providerResults?: (data: ResultType[]) => void;
+        providerInput?: string;
 }
 declare const Map: React.Component<MapProps>
 export default Map

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,23 +3,33 @@ import React from 'react';
 
 type LatType = {
         northeast: {
-                lat: Number,
-                lng: Number,
+                lat: Number
+                lng: Number
         },
         southwest: {
-                lat: Number,
-                lng: Number,
+                lat: Number
+                lng: Number
         }
 }
+type RawType = {
+        boundingbox: string[]
+        class: string
+        display_name: string
+        importance: number
+        lat: string
+        license: string
+        lon: string
+        osm_id: number
+        osm_type: string
+        place_id: number
+        type: string
+}
 type ResultType = {
-        x: Number, // lon,
-        y: Number, // lat,
-        label: String, // formatted address
-        bounds: [
-                [Number, Number], // s, w - lat, lon
-                [Number, Number], // n, e - lat, lon
-        ],
-        raw: {}, // raw provider result
+        x: string // lon,
+        y: string // lat,
+        label: string // formatted address
+        bounds: string[][]
+        raw: RawType // raw provider result
 };
 export interface MapProps<> {
         editable: boolean;
@@ -32,7 +42,7 @@ export interface MapProps<> {
         markerHtml: string;
         mapCount: number;
         getBounding?: (data?: LatType) => void;
-        providerResults?: (data: ResultType[]) => void;
+        providerResults: (data: ResultType[] | []) => void;
         providerInput?: string;
 }
 declare const Map: React.Component<MapProps>


### PR DESCRIPTION
Fixed types for `index.d.ts`

implemented the following props.

### providerInput:
_Type:_ `string`

_Optional:_ `true`

_Description:_ String to use to query geosearch control.

``` NOTE: Currently only available when provider = 'openstreet' ```


### providerResults: (data: ResultType[] | []) => void;
_Type:_ `Function`

_Optional:_ `true`

_Description:_ Function to return geosearch results to UI.

_Required:_ If `providerInput` is supplied to Map. 