### PR TITLE
Hide geosearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,11 @@ _Description:_ Function to return geosearch results to UI.
 
 _Required:_ If `providerInput` is supplied to Map. 
 
+### hideSearch:
+_Type:_ `boolean`
+
+_Optional:_ `true`
+
+_Default:_ `false`
+
+_Description:_ A flag to disable/hide the search button included on the map.

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ export interface MapProps {
     getBounding?: (data?: LatType) => void;
     providerResults?: (data: ResultType[] | []) => void;
     providerInput?: string;
+    hideSearch?: boolean
 }
 declare class Map extends React.Component<MapProps, any> {}
 export default Map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-leaflet",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A React map component that allows geoJSON shapes to be drawn, edited, and loaded into leaflet layers",
   "main": "dist/Map.js",
   "types": "dist/index.d.ts",

--- a/src/Map.js
+++ b/src/Map.js
@@ -39,7 +39,8 @@ class Map extends React.Component {
     );
     tiles.addTo(map);
     if (provider) {
-      map.addControl(
+
+      !this.props.hideSearch && map.addControl(
         new GeoSearchControl({
           provider,
           animateZoom: false,
@@ -416,7 +417,8 @@ Map.defaultProps = {
   center: [38.194706, -85.71053],
   markerHtml:
     '<svg width="8" height="8" version="1.1" xmlns="http://www.w3.org/2000/svg"> <circle cx="4" cy="4" r="4" stroke="red" fill="red" stroke-width="0" /></svg>',
-  searchProvider: 'google'
+  searchProvider: 'google',
+  hideSearch: false
 };
 
 export default Map;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,6 +44,7 @@ export interface MapProps<> {
         getBounding?: (data?: LatType) => void;
         providerResults?: (data: ResultType[] | []) => void;
         providerInput?: string;
+        hideSearch?: boolean;
 }
 declare const Map: React.Component<MapProps>
 export default Map


### PR DESCRIPTION
Hide the geosearch button from map:

![image](https://user-images.githubusercontent.com/22862620/104615389-336f2e80-5657-11eb-9336-c7cfde9d1bf5.png)

hideSearch: `boolean` defaults to false.