### PR TITLE
Tooltip templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ _Description:_ Allows outside results from geolocation to be passed to the map. 
 
 ### tooltipContent:
 _Type:_ ```{
-    comp: string;
-    func: () => void
-    tooltip: string;
+    comp?: string;
+    func?: () => void
+    tooltip?: string;
+    values?: Array<string>
 }```
 
 _Optional:_ `true`
@@ -192,3 +193,27 @@ _Description:_
 comp: is the popup content when a marker is clicked
 func: function to pass into popup
 tooltip: tooltip content.
+values: If template string is used, This is the array of fields to check in the features `properties` field.
+
+_Example:_
+This works for popup/tooltip
+```
+comp: `<div>this is a {var}</div>`
+values: ['var']
+and the GeoJSON: 
+
+{
+    type: 'Feature',
+    properties: {
+      var: 'test'
+      key: 'cbb7672e-1e85-4c0b-8bcb-5bfc5af2d736',
+    },
+    geometry: {
+      type: 'Point',
+      coordinates: [-85.76399, 38.257058],
+    },
+  },```
+
+  compiles to 
+
+  ```<div>this is a test</div>```

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ type ToolTipType = {
     comp: string;
     func: () => void
     tooltip: string;
+    values: Array<string>
 }
 
 type LatType = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-leaflet",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A React map component that allows geoJSON shapes to be drawn, edited, and loaded into leaflet layers",
   "main": "dist/Map.js",
   "types": "dist/index.d.ts",

--- a/src/Map.js
+++ b/src/Map.js
@@ -329,10 +329,8 @@ class Map extends React.Component {
               const options = {};
               this.props.tooltipContent.values &&
               this.props.tooltipContent.values.map(currentVal => {
-                console.log(currentFeature)
                 return options[currentVal] = currentFeature.properties[currentVal] || 'N/A' 
               })
-              console.log(options)
               const customTip = (component) => {
                 if (!pointMarker.isPopupOpen()) pointMarker.bindTooltip(component, {direction: 'top'}).openTooltip();
               }
@@ -424,9 +422,6 @@ class Map extends React.Component {
     return true;
   }
   componentWillReceiveProps(nextProps) {
-    if (nextProps.tooltipContent && (nextProps.tooltipContent.comp !== this.props.tooltipContent.comp)) {
-      return true
-    }
     if (nextProps.providerInput !== this.props.providerInput) {
       const openStreet = new OpenStreetMapProvider({ params: { countrycodes: 'us' } })
       const result = openStreet.search({ query: nextProps.providerInput }).then((result) => this.props.providerResults(result))

--- a/src/Map.js
+++ b/src/Map.js
@@ -326,20 +326,27 @@ class Map extends React.Component {
             const pointLayer = L.GeoJSON.geometryToLayer(currentFeature)
             const pointMarker = L.marker(pointLayer._latlng, marker_options)
             if (this.props.tooltipContent) {
+              const options = {};
+              this.props.tooltipContent.values &&
+              this.props.tooltipContent.values.map(currentVal => {
+                console.log(currentFeature)
+                return options[currentVal] = currentFeature.properties[currentVal] || 'N/A' 
+              })
+              console.log(options)
               const customTip = (component) => {
-                if (!pointMarker.isPopupOpen()) pointMarker.bindTooltip(component).openTooltip();
+                if (!pointMarker.isPopupOpen()) pointMarker.bindTooltip(component, {direction: 'top'}).openTooltip();
               }
               const customPop = () => {
                 pointMarker.unbindTooltip();
               }
 
-              pointMarker.bindPopup(this.props.tooltipContent.comp)
-              pointMarker.on('mouseover', () => customTip(this.props.tooltipContent.tooltip));
+              pointMarker.bindPopup( L.Util.template(this.props.tooltipContent.comp, options))
+              pointMarker.on('mouseover', () => customTip(L.Util.template(this.props.tooltipContent.tooltip, options)));
               pointMarker.on('click', () => customPop());
-              pointMarker.on('popupopen', () => L.DomEvent.on(document.getElementById('test'),
-                'click',
-                () => this.props.tooltipContent.func(true)
-              ))
+              // pointMarker.on('popupopen', () => L.DomEvent.on(document.getElementById('test'),
+              //   'click',
+              //   () => this.props.tooltipContent.func(true)
+              // ))
               // pointMarker.on('popupclose', () => this.props.tooltipContent.func(false))
 
             }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,8 @@ type ToolTipType = {
         comp: string;
         func: () => void
         tooltip: string
+        values: Array<string>
+
 }
 
 type LatType = {


### PR DESCRIPTION
### tooltipContent:
_Type:_ ```{
    comp?: string;
    func?: () => void;
    tooltip?: string;
    values?: Array<string>;
}```

_Optional:_ `true`

_Description:_ 
comp: is the popup content when a marker is clicked
func: function to pass into popup
tooltip: tooltip content.
values: If template string is used, This is the array of fields to check in the features `properties` field.

_Example:_
This works for popup/tooltip
```
comp: `<div>this is a {var}</div>`
values: ['var']
and the GeoJSON: 

{
    type: 'Feature',
    properties: {
      var: 'test'
      key: 'cbb7672e-1e85-4c0b-8bcb-5bfc5af2d736',
    },
    geometry: {
      type: 'Point',
      coordinates: [-85.76399, 38.257058],
    },
  },```

  compiles to 

  ```<div>this is a test</div>```
