### PR TITLE
;fixed props for geolocate to stop rerender, added Leaflet-Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ Check `index.d.ts` to see the props.
 
 # Props:
 
+## tileProvider:
+
+_Type:_ `string`
+
+_optional_: `true`
+
+_Default:_ `OpenStreetMap.Mapnik`
+
+_Description:_ List of providers are [Here](https://github.com/leaflet-extras/leaflet-providers/blob/master/leaflet-providers.jshttps://github.com/leaflet-extras/leaflet-providers/blob/master/leaflet-providers.js)
+Folling keys are `MAP_CREATOR.variant` ex: `Esri.WorldStreetMap` 
+
 ## editable
 
 _Type:_ `boolean`
@@ -104,8 +115,10 @@ _Default:_ `<svg width="8" height="8" version="1.1" xmlns="http://www.w3.org/200
 
 _Description:_ Icon for marker when searching
 
+---
 
 ### mapCount:
+
 _Type:_ `number`
 
 _Default:_ `''`
@@ -113,7 +126,10 @@ _Default:_ `''`
 _Description:_ Interger to render more than 1 map on the same page. (i.e....
 `mapCount={1}` makes Map Div ID:`mapid1`)
 
+---
+
 ### getBounding: 
+
 _Type:_ `Function`
 
 _Default:_`false`
@@ -136,7 +152,11 @@ _Example_: `(data) => data` where data is:
   }
   zoom: 13
 }
+
+---
+
 ### providerInput:
+
 _Type:_ `string`
 
 _Optional:_ `true`
@@ -145,17 +165,22 @@ _Description:_ String to use to query geosearch control.
 
 ``` NOTE: Currently only available when provider = 'openstreet' ```
 
+---
 
-### providerResults: (data: ResultType[] | []) => void;
+### providerResults: (data: ResultType[] | []) => void
+
 _Type:_ `Function`
 
 _Optional:_ `true`
 
 _Description:_ Function to return geosearch results to UI.
 
-_Required:_ If `providerInput` is supplied to Map. 
+_Required:_ If `providerInput` is supplied to Map.
+
+---
 
 ### hideSearch:
+
 _Type:_ `boolean`
 
 _Optional:_ `true`
@@ -164,7 +189,10 @@ _Default:_ `false`
 
 _Description:_ A flag to disable/hide the search button included on the map.
 
+---
+
 ### geoLocate:
+
 _Type:_ ```type ResultType = {
         x: string // lon,
         y: string // lat,
@@ -179,7 +207,10 @@ _Description:_ Allows outside results from geolocation to be passed to the map. 
 
 ```NOTE: Currently only works with `openstreet` as the `provider`.```
 
+---
+
 ### tooltipContent:
+
 _Type:_ ```{
     comp?: string;
     func?: () => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ type ResultType = {
 };
 
 export interface MapProps {
+    tileProvider: string;
     editable: boolean;
     cutMode?: boolean;
     onShapeChange: (feature?: GeoJSON) => void;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "leaflet": "^1.4.0",
     "leaflet-easybutton": "^2.4.0",
     "leaflet-geosearch": "^2.7.0",
+    "leaflet-providers": "^1.11.0",
     "leaflet.pm": "^2.0.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-leaflet",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A React map component that allows geoJSON shapes to be drawn, edited, and loaded into leaflet layers",
   "main": "dist/Map.js",
   "types": "dist/index.d.ts",

--- a/src/Map.js
+++ b/src/Map.js
@@ -2,6 +2,7 @@ import React from "react";
 import L from "leaflet";
 import "leaflet.pm";
 import "leaflet-easybutton";
+import "leaflet-providers"
 import noop from "lodash.noop";
 import isEqual from "lodash.isequal";
 import uuid from "uuid/v4";
@@ -29,17 +30,9 @@ class Map extends React.Component {
     // Set initial view at the center prop with a zoom level of 13
     map.setView(center, 13);
     const provider = providerSwitch(this.props.searchProvider, this.props.apiKey)
-    const tiles = L.tileLayer(
-      "https://{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
-      {
-        attribution:
-          '&copy; MapData: Google',
-        subdomains: ["mt0", "mt1", "mt2", "mt3"]
-      }
-    );
+    const tiles = L.tileLayer.provider(this.props.tileProvider || 'OpenStreetMap.Mapnik');
     tiles.addTo(map);
     if (provider) {
-
       !this.props.hideSearch && map.addControl(
         new GeoSearchControl({
           provider,
@@ -433,7 +426,8 @@ class Map extends React.Component {
       const result = openStreet.search({ query: nextProps.providerInput }).then((result) => this.props.providerResults(result))
       return true;
     }
-    if (nextProps.geoLocate !== this.props.geoLocate) {
+    // Is GeoLocate Different? Yes? ReCenter map over New location
+    if (!isEqual(nextProps.geoLocate, this.props.geoLocate)) {
       const resultBounds = nextProps.geoLocate[0].bounds
         ? new L.LatLngBounds(nextProps.geoLocate[0].bounds)
         : new L.LatLng(nextProps.geoLocate[0].y, nextProps.geoLocate[0].x).toBounds(10);
@@ -445,6 +439,7 @@ class Map extends React.Component {
    
   }
   componentDidUpdate(prevState) {
+    console.log(this.state, this.props)
     if (this.state.features.length === 0) return this.state.mapState.eachLayer((layer) => !layer._url && layer.remove())
     if (prevState.features !== this.state.features) {
       const marker_options = {
@@ -552,7 +547,8 @@ Map.defaultProps = {
   markerHtml:
     '<svg width="8" height="8" version="1.1" xmlns="http://www.w3.org/2000/svg"> <circle cx="4" cy="4" r="4" stroke="red" fill="red" stroke-width="0" /></svg>',
   searchProvider: 'google',
-  hideSearch: false
+  hideSearch: false,
+  tileProvider: 'OpenStreetMap.Mapnik'
 };
 
 export default Map;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,6 +44,7 @@ type ResultType = {
         raw: RawType // raw provider result
 };
 export interface MapProps<> {
+        tileProvider: string;
         editable: boolean;
         cutMode?: boolean;
         onShapeChange: (feature: GeoJSON) => Array<GeoJSON>;


### PR DESCRIPTION
Geolocate wasn't changing and getBounds was being called repeatedly every time provider input was changing. using `isEqual` from lodash to check deep equal for geoLocate location

Also implemented `leaflet-providers` [Github](https://github.com/leaflet-extras/leaflet-providers)

## tileProvider:

_Type:_ `string`

_optional_: `true`

_Default:_ `OpenStreetMap.Mapnik`

_Description:_ List of providers are [Here](https://github.com/leaflet-extras/leaflet-providers/blob/master/leaflet-providers.jshttps://github.com/leaflet-extras/leaflet-providers/blob/master/leaflet-providers.js)
Folling keys are `MAP_CREATOR.variant` ex: `Esri.WorldStreetMap` 

Allows tileLayer to be added as prop and easily switched.
