### PR TITLE
Remove provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,30 +155,6 @@ _Example_: `(data) => data` where data is:
 
 ---
 
-### providerInput:
-
-_Type:_ `string`
-
-_Optional:_ `true`
-
-_Description:_ String to use to query geosearch control.
-
-``` NOTE: Currently only available when provider = 'openstreet' ```
-
----
-
-### providerResults: (data: ResultType[] | []) => void
-
-_Type:_ `Function`
-
-_Optional:_ `true`
-
-_Description:_ Function to return geosearch results to UI.
-
-_Required:_ If `providerInput` is supplied to Map.
-
----
-
 ### hideSearch:
 
 _Type:_ `boolean`

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,8 +55,6 @@ export interface MapProps {
     markerHtml?: string;
     mapCount?: number;
     getBounding?: (data?: BoundZoomType) => void;
-    providerResults?: (data: ResultType[] | []) => void;
-    providerInput?: string;
     hideSearch?: boolean
     geoLocate?: ResultType[];
     tooltipContent?: ToolTipType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-leaflet",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "description": "A React map component that allows geoJSON shapes to be drawn, edited, and loaded into leaflet layers",
   "main": "dist/Map.js",
   "types": "dist/index.d.ts",

--- a/src/Map.css
+++ b/src/Map.css
@@ -1039,21 +1039,6 @@ div[id^='mapid'] {
   text-indent: 18px;
 }
 
-html,
-body {
-  font-family: "Open Sans", sans-serif;
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-}
 
 .leaflet-control-geosearch.bar {
   position: absolute !important;

--- a/src/Map.js
+++ b/src/Map.js
@@ -421,11 +421,6 @@ class Map extends React.Component {
     if (nextProps.features !== prevProps.features) {
       this.setState({features: nextProps.features}, () => this.state.mapState.invalidateSize())
     }
-    if (nextProps.providerInput !== this.props.providerInput) {
-      const openStreet = new OpenStreetMapProvider({ params: { countrycodes: 'us' } })
-      const result = openStreet.search({ query: nextProps.providerInput }).then((result) => this.props.providerResults(result))
-      return true;
-    }
     // Is GeoLocate Different? Yes? ReCenter map over New location
     if (!isEqual(nextProps.geoLocate, this.props.geoLocate)) {
       const resultBounds = nextProps.geoLocate[0].bounds

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,8 +55,6 @@ export interface MapProps<> {
         markerHtml: string;
         mapCount: number;
         getBounding?: (data?: BoundZoomType) => void;
-        providerResults?: (data: ResultType[] | []) => void;
-        providerInput?: string;
         hideSearch?: boolean;
         geoLocate?: ResultType[];
         tooltipContent?: ToolTipType;


### PR DESCRIPTION
Removed `providerInput`  & `providerResults` in favor of allowing outside the map geosearching.

